### PR TITLE
Iss346 - Updating transit trips weighting

### DIFF
--- a/06_neighborhoods/Transportation/transit_trips_cost_city.qmd
+++ b/06_neighborhoods/Transportation/transit_trips_cost_city.qmd
@@ -269,7 +269,7 @@ Data quality can be 1 when most of the tracts that fall in the place (e.g., >50%
 ```{r}
 transit_trips_city_2015 <- transit_trips_city_2015 %>% 
   dplyr::group_by(state, place) %>% 
-  dplyr::summarize(index_transit_trips = sum(transit_trips_80ami*afact, na.rm = TRUE),
+  dplyr::summarize(index_transit_trips = round(weighted.mean(transit_trips_80ami, w = households*afact, na.rm = TRUE), 2),
                    n = n(),
                    dq = sum(afact > 0.5, na.rm = TRUE)
   )
@@ -320,7 +320,7 @@ Collapse to places and also create data quality marker data quality can be 1 whe
 ```{r}
 transit_trips_city_2019 <- transit_trips_city_2019 %>% 
   dplyr::group_by(state, place) %>% 
-  dplyr::summarize(index_transit_trips = sum(transit_trips_80ami*afact, na.rm = TRUE),
+  dplyr::summarize(index_transit_trips = round(weighted.mean(transit_trips_80ami, w = households*afact, na.rm = TRUE), 2),
                    n = n(),
                    dq = sum(afact > 0.5, na.rm = TRUE)
   )

--- a/06_neighborhoods/Transportation/transit_trips_cost_city_subgroups.qmd
+++ b/06_neighborhoods/Transportation/transit_trips_cost_city_subgroups.qmd
@@ -565,7 +565,7 @@ cost_all_19 <- cost_data_2019 %>%
 
 trips_all_15 <- trips_data_2015 %>%
   group_by(state, place) %>%
-  summarize(index_transit_trips = sum(transit_trips_80ami*households*afact, na.rm = TRUE),
+  summarize(index_transit_trips = round(weighted.mean(transit_trips_80ami, w = households*afact, na.rm = TRUE), 2),
             n = n(),
             dq = sum(afact > 0.5, na.rm = TRUE)
             ) %>%
@@ -580,7 +580,7 @@ trips_all_15 <- trips_data_2015 %>%
 ```{r}
 trips_all_19 <- trips_data_2019 %>%
   group_by(state, place) %>%
-  summarize(index_transit_trips = sum(transit_trips_80ami*households*afact, na.rm = TRUE),
+  summarize(index_transit_trips = round(weighted.mean(transit_trips_80ami, w = households*afact, na.rm = TRUE), 2),
             n = n(),
             dq = sum(afact > 0.5, na.rm = TRUE)
   ) %>%
@@ -653,7 +653,7 @@ cost_by_race_19 <- cost_data_2019 %>%
 ```{r}
 trips_by_race_15 <- trips_data_2015 %>%
   group_by(state, place, race_category) %>%
-  summarize(transit_trips = sum(transit_trips_80ami*households*afact, na.rm = TRUE),
+  summarize(transit_trips = round(weighted.mean(transit_trips_80ami, w = households*afact, na.rm = TRUE), 2),
             n = n(),
             dq = sum(afact > 0.5, na.rm = TRUE)
             )%>%
@@ -665,7 +665,7 @@ trips_by_race_15 <- trips_data_2015 %>%
 ```{r}
 trips_by_race_19 <- trips_data_2019 %>%
   group_by(state, place, race_category) %>%
-  summarize(transit_trips = sum(transit_trips_80ami*households*afact, na.rm = TRUE),
+  summarize(transit_trips = round(weighted.mean(transit_trips_80ami, w = households*afact, na.rm = TRUE), 2),
             n = n(),
             dq = sum(afact > 0.5, na.rm = TRUE)
             )%>%

--- a/06_neighborhoods/Transportation/transit_trips_cost_county_subgroups.qmd
+++ b/06_neighborhoods/Transportation/transit_trips_cost_county_subgroups.qmd
@@ -504,7 +504,7 @@ cost_all_19 <- cost_data_2019 %>%
 ```{r}
 trips_all_15 <- trips_data_2015 %>%
   group_by(state, county) %>%
-  summarize(index_transit_trips = sum(transit_trips_80ami * households, na.rm = TRUE),
+  summarize(index_transit_trips = weighted.mean(x = transit_trips_80ami, w = households, na.rm = TRUE),
             households = sum(households)) %>%
   mutate(subgroup_type = "race-ethnicity",
          subgroup = "All")
@@ -514,7 +514,7 @@ trips_all_15 <- trips_data_2015 %>%
 ```{r}
 trips_all_19 <- trips_data_2019 %>%
   group_by(state, county) %>%
-  summarize(index_transit_trips = sum(transit_trips_80ami * households, na.rm = TRUE),
+  summarize(index_transit_trips = weighted.mean(x = transit_trips_80ami, w = households, na.rm = TRUE),
             households = sum(households)) %>%
   mutate(subgroup_type = "race-ethnicity",
          subgroup = "All")
@@ -608,7 +608,7 @@ cost_by_race_19 <- cost_data_2019 %>%
 ```{r}
 trips_by_race_15 <- trips_data_2015 %>%
   group_by(state, county, race_category) %>%
-  summarize(transit_trips = sum(transit_trips_80ami * households, na.rm = TRUE),
+  summarize(transit_trips = weighted.mean(x = transit_trips_80ami, w = households, na.rm = TRUE),
             households = sum(households))
 
 ```
@@ -616,7 +616,7 @@ trips_by_race_15 <- trips_data_2015 %>%
 ```{r}
 trips_by_race_19 <- trips_data_2019 %>%
   group_by(state, county, race_category) %>%
-  summarize(transit_trips = sum(transit_trips_80ami * households, na.rm = TRUE),
+  summarize(transit_trips = weighted.mean(x = transit_trips_80ami, w = households, na.rm = TRUE),
             households = sum(households))
 
 ```


### PR DESCRIPTION
Reverting transit trips collapse to a mean instead of a sum. Affects county subgroup, city, and city subgroup files. And their outputs, which I have not run